### PR TITLE
Add feature to store & fetch a list of rules from JSON file

### DIFF
--- a/py_rules/storages.py
+++ b/py_rules/storages.py
@@ -60,6 +60,41 @@ class JSONRuleStorage(RuleStorage):
             json.dump(data, f, indent=4)
 
 
+class JSONMultiRuleStorage(RuleStorage):
+  """
+  Multiple RuleStorage class for JSON files.
+  """
+
+  format = 'json'
+
+  def __init__(self, file_path):
+      """
+      Initialize the loader with a file_path.
+      """
+      super().__init__()
+      self.file_path = file_path
+      # validate that the file_path is valid and is a json file
+      if not self.file_path.endswith('.json'):
+          raise InvalidRuleError('Invalid file type. Only JSON files are supported.')
+
+  def load(self):
+      """
+      Load a rule from a JSON file.
+      """
+      data = []
+      with open(self.file_path) as f:
+          data = json.load(f)
+      return [self.parser.parse(rule) for rule in data]
+
+  def store(self, rule):
+      """
+      Store a rule in a JSON file.
+      """
+      data = rule.to_dict()
+      with open(self.file_path, 'w') as f:
+          json.dump(data, f, indent=4)
+
+
 class PickledRuleStorage(RuleStorage):
     """
     RuleStorage class for Pickle files.

--- a/py_rules/storages.py
+++ b/py_rules/storages.py
@@ -60,22 +60,11 @@ class JSONRuleStorage(RuleStorage):
             json.dump(data, f, indent=4)
 
 
-class JSONMultiRuleStorage(RuleStorage):
+class JSONMultiRuleStorage(JSONRuleStorage):
   """
   Multiple RuleStorage class for JSON files.
   """
 
-  format = 'json'
-
-  def __init__(self, file_path):
-      """
-      Initialize the loader with a file_path.
-      """
-      super().__init__()
-      self.file_path = file_path
-      # validate that the file_path is valid and is a json file
-      if not self.file_path.endswith('.json'):
-          raise InvalidRuleError('Invalid file type. Only JSON files are supported.')
 
   def load(self):
       """
@@ -86,13 +75,11 @@ class JSONMultiRuleStorage(RuleStorage):
           data = json.load(f)
       return [self.parser.parse(rule) for rule in data]
 
-  def store(self, rule):
+  def store(self, rules):
       """
-      Store a rule in a JSON file.
+      Store a list of rule in a JSON file.
       """
-      data = rule.to_dict()
-      with open(self.file_path, 'w') as f:
-          json.dump(data, f, indent=4)
+      super().store(rules)
 
 
 class PickledRuleStorage(RuleStorage):

--- a/py_rules/storages.py
+++ b/py_rules/storages.py
@@ -83,7 +83,7 @@ class JSONMultiRuleStorage(JSONRuleStorage):
       Store a list of rule in a JSON file.
       """
       if not isinstance(rules, list):
-          raise TypeError("Invalid dat type, expecting a list here")
+          raise TypeError("Invalid data type, expecting a list here")
       super().store(rules)
 
 

--- a/py_rules/storages.py
+++ b/py_rules/storages.py
@@ -73,12 +73,17 @@ class JSONMultiRuleStorage(JSONRuleStorage):
       data = []
       with open(self.file_path) as f:
           data = json.load(f)
+      if not isinstance(data, list):
+        raise TypeError("Invalid data type")
+
       return [self.parser.parse(rule) for rule in data]
 
   def store(self, rules):
       """
       Store a list of rule in a JSON file.
       """
+      if not isinstance(rules, list):
+          raise TypeError("Invalid dat type, expecting a list here")
       super().store(rules)
 
 


### PR DESCRIPTION
Adding support to store and fetch list of Rule from JSON file

Format of Multi Rule Json may look like

```json

[
  {
    "metadata": {
        "version": "0.3.0",
        "type": "Rule",
        "required_context_parameters": ["temperature"],
        "name": "Temperature Rule"
    },
    "if": {
        "condition": {
            "metadata": {
                "version": "0.3.0",
                "type": "Condition",
                "required_context_parameters": ["temperature"]
            },
            "variable": "temperature",
            "operator": ">",
            "value": {"type": "int", "value": 30}
        }
    },
    "then": {"result": {"message": {"type": "str", "value": "It is hot!"}}}
  },
  {
    "metadata": {
        "version": "0.3.0",
        "type": "Rule",
        "required_context_parameters": ["wind_speed"],
        "name": "Wind Speed Rule"
    },
    "if": {
        "condition": {
            "metadata": {
                "version": "0.3.0",
                "type": "Condition",
                "required_context_parameters": ["wind_speed"]
            },
            "variable": "wind_speed",
            "operator": "<",
            "value": {"type": "int", "value": 50}
        }
    },
    "then": {"result": {"message": {"type": "str", "value": "Low Wind is awesome!"}}}
  }
]
```